### PR TITLE
fixed bug in chart date display

### DIFF
--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -114,16 +114,16 @@ export default class extends Controller {
   formatDates() {
     let dateOption;
     switch(this.aggValue) {
-      case "day":
+      case "d":
         dateOption = { weekday: "short", year: "2-digit", month: "short", day: "2-digit" };
         break;
-      case "week":
+      case "w":
         dateOption = { year: "numeric", month: "short", day: "2-digit" };
         break;
-      case "month":
+      case "m":
         dateOption = { year: "numeric", month: "short" };
         break;
-      case "year":
+      case "y":
         dateOption = { year: "numeric"};
         break;
     }


### PR DESCRIPTION
Fixed a bug in the also newly released chart date display style. For the date aggregation, we changed the aggregation variable from full names ("day", "week",...) to ("d", "w",...) and therefore the switch statement for the chart date display setting didn't work anymore.