### PR TITLE
improved fugus mobile layout

### DIFF
--- a/app/views/events/_selections.html.erb
+++ b/app/views/events/_selections.html.erb
@@ -1,10 +1,10 @@
 <div
-  class="flex flex-row w-full items-center justify-between"
+  class="flex flex-col md:flex-row w-full items-left md:items-center justify-between"
   data-controller="event selection"
   data-event-aggregation-value="<%= aggregation %>"
 >
-  <div class="flex flex-row gap-x-5 items-center justify-start">
-    <div class="flex flex-col items-start justify-center">
+  <div class="flex flex-col md:flex-row  gap-x-5 items-left md:items-center justify-start">
+    <div class="flex flex-col items-start justify-center mb-2 md:mb-0">
       <%= label_tag 'events', 'Events', class: "text-sm font-medium mb-2" %>
       <%= select_tag "events",
           raw(event_select_options(param_data, aggregation, event_names)),
@@ -12,7 +12,7 @@
           class: "w-56 text-sm"
       %>
     </div>
-    <div class="flex flex-col items-start justify-center">
+    <div class="flex flex-col items-start justify-center mb-2 md:mb-0">
       <%= label_tag 'properties', 'Properties', class: "text-sm font-medium mb-2" %>
       <%= select_tag "properties",
           raw(property_select_options(param_data, aggregation, properties)),
@@ -20,7 +20,7 @@
           class: "w-44 text-sm"
       %>
     </div>
-    <div class="flex flex-col items-start justify-center">
+    <div class="flex flex-col items-start justify-center mb-2 md:mb-0">
       <%= label_tag 'aggregation', 'Aggregation', class: "text-sm font-medium mb-2" %>
       <%= select_tag "aggregation",
           raw(agg_select_options(param_data, aggregation, possible_aggregations)),
@@ -29,8 +29,8 @@
       %>
     </div>
   </div>
-  <div class="flex flex-row gap-x-5 items-center justify-start">
-    <div class="flex flex-col items-start justify-center">
+  <div class="flex flex-col md:flex-row  gap-x-5 items-left md:items-center justify-start">
+    <div class="flex flex-col items-start justify-center mb-2 md:mb-0">
       <%= label_tag 'date_range', 'Date Range', class: "text-sm font-medium mb-2" %>
       <%= select_tag "date_range",
           raw(date_select_options(param_data, aggregation, "event")),

--- a/app/views/funnels/_selections.html.erb
+++ b/app/views/funnels/_selections.html.erb
@@ -1,8 +1,8 @@
 <div
-  class="flex flex-row w-full items-center justify-between"
+  class="flex flex-col md:flex-row w-full items-left md:items-center justify-between"
   data-controller="selection"
 >
-  <div class="flex flex-row gap-x-5 items-center justify-start">
+  <div class="flex flex-col md:flex-row gap-x-5 items-left md:items-center justify-start">
     <div class="flex flex-col items-start justify-center">
       <%= label_tag 'funnels', 'Funnels', class: "text-sm font-medium mb-2" %>
       <%= select_tag "funnels",
@@ -12,7 +12,7 @@
       %>
     </div>
   </div>
-  <div class="flex flex-row gap-x-5 items-center justify-start">
+  <div class="flex flex-col md:flex-row gap-x-5 items-left md:items-center justify-start">
     <div class="flex flex-col items-start justify-center">
       <%= label_tag 'date_range', 'Date Range', class: "text-sm font-medium mb-2" %>
       <%= select_tag "date_range",

--- a/app/views/partials/_footer.html.erb
+++ b/app/views/partials/_footer.html.erb
@@ -1,17 +1,17 @@
 <footer class="bg-green-100 mt-auto text-gray-600">
-  <div class="flex flex-row items-center justify-between p-6 w-full">
-    <div>
+  <div class="flex flex-col md:flex-row items-center justify-between p-6 w-full gap-y-4 md:gap-y-0">
+    <div class="text-center md:text-left">
       Fugu is 100% self-funded, independent and hosted in the EU.
       By <a href="https://twitter.com/canolcer" target="_blank">@canolcer</a>.
     </div>
-    <div class="flex flex-row items-center justify-center">
-      <a href="https://fugu.lol" target="_blank" class="no-underline font-normal mx-2">About</a>
-      <a href="https://docs.fugu.lol" target="_blank" class="no-underline font-normal mx-2">Docs</a>
-      <a href="https://github.com/shafy/fugu" target="_blank" class="no-underline font-normal mx-2">GitHub</a>
-      <a href="https://fugu.lol/legal/terms" class="no-underline font-normal mx-2" target="_blank">Terms</a>
-      <a href="https://fugu.lol/legal/privacy" class="no-underline font-normal mx-2" target="_blank">Privacy</a>
-      <a href="https://fugu.lol/legal/dpa" class="no-underline font-normal mx-2" target="_blank">DPA</a>
-      <a href="https://fugu.lol/legal/imprint" class="no-underline font-normal mx-2" target="_blank">Imprint</a>
+    <div class="flex flex-wrap max-w-full items-center justify-center gap-x-4">
+      <a href="https://fugu.lol" target="_blank" class="no-underline font-normal">About</a>
+      <a href="https://docs.fugu.lol" target="_blank" class="no-underline font-normal">Docs</a>
+      <a href="https://github.com/shafy/fugu" target="_blank" class="no-underline font-normal">GitHub</a>
+      <a href="https://fugu.lol/legal/terms" class="no-underline font-normal" target="_blank">Terms</a>
+      <a href="https://fugu.lol/legal/privacy" class="no-underline font-normal" target="_blank">Privacy</a>
+      <a href="https://fugu.lol/legal/dpa" class="no-underline font-normal" target="_blank">DPA</a>
+      <a href="https://fugu.lol/legal/imprint" class="no-underline font-normal" target="_blank">Imprint</a>
     </div>
   </div>
 </footer>

--- a/app/views/partials/_narrow_box.erb
+++ b/app/views/partials/_narrow_box.erb
@@ -1,3 +1,3 @@
-<div class="flex flex-col w-32rem mb-4 p-4 rounded-md shadow-md bg-yellow-50 gap-x-5">
+<div class="flex flex-col w-full md:w-32rem mb-4 p-4 rounded-md shadow-md bg-yellow-50 gap-x-5">
   <%= yield %>
 </div>


### PR DESCRIPTION
Changed selection menu to column and on left side
<img width="420" alt="Screenshot 2022-01-24 at 15 45 26" src="https://user-images.githubusercontent.com/32681439/150804775-0a2edbc8-a760-49ff-b2ce-4c4dac995911.png">

Changed footer to wrap
<img width="459" alt="Screenshot 2022-01-24 at 15 45 35" src="https://user-images.githubusercontent.com/32681439/150804802-930d69c3-b511-44e0-9bbd-a5e1e3359fe4.png">

Changed container from fixed to full size
<img width="415" alt="Screenshot 2022-01-24 at 15 46 09" src="https://user-images.githubusercontent.com/32681439/150804813-8087faf6-9606-40ca-8def-2453aa9a462d.png">

closes #24 

