### PR TITLE
added percentage and total value to funnel bar chart

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/stimulus-importmap-autoloader"
-import "chart.js"
-import "chartjs-plugin-datalabels"
 import "controllers"
 import "@hotwired/turbo-rails"

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,6 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/stimulus-importmap-autoloader"
 import "chart.js"
+import "chartjs-plugin-datalabels"
 import "controllers"
 import "@hotwired/turbo-rails"

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -3,7 +3,8 @@ import { Controller } from "@hotwired/stimulus"
 import { Chart, registerables } from "chart.js";
 Chart.register(...registerables);
 
-// import "chartjs-plugin-colorschemes";
+import ChartDataLabels from "chartjs-plugin-datalabels";
+Chart.register(ChartDataLabels);
 
 export default class extends Controller {
   static targets = [ "chart"]
@@ -40,7 +41,7 @@ export default class extends Controller {
             ticks: {
               format: { style: "decimal" },
               precision: 0,
-              padding: 10,
+              padding: 10
             },
             grid: {
               color: "rgba(254, 243, 199, 0.7)",
@@ -59,6 +60,11 @@ export default class extends Controller {
           legend: {
              display: this.displayLegend(),
              position: 'bottom'
+          },
+          datalabels: {
+            labels: {
+              title: null
+            }
           }
         }
       }

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -1,10 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
-
 import { Chart, registerables } from "chart.js";
-Chart.register(...registerables);
 
-import ChartDataLabels from "chartjs-plugin-datalabels";
-Chart.register(ChartDataLabels);
+Chart.register(...registerables);
 
 export default class extends Controller {
   static targets = [ "chart"]
@@ -60,11 +57,6 @@ export default class extends Controller {
           legend: {
              display: this.displayLegend(),
              position: 'bottom'
-          },
-          datalabels: {
-            labels: {
-              title: null
-            }
           }
         }
       }

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -33,7 +33,7 @@ export default class extends Controller {
         maintainAspectRatio: false,
         scales: {
           y: {
-            grace: '10%',
+            grace: "10%",
             beginAtZero: true,
             ticks: {
               format: { style: "decimal" },
@@ -56,7 +56,7 @@ export default class extends Controller {
         plugins: {
           legend: {
              display: this.displayLegend(),
-             position: 'bottom'
+             position: "bottom"
           }
         }
       }

--- a/app/javascript/controllers/funnel_chart_controller.js
+++ b/app/javascript/controllers/funnel_chart_controller.js
@@ -34,7 +34,7 @@ export default class extends Controller {
         maintainAspectRatio: false,
         scales: {
           y: {
-            grace: '10%',
+            grace: "10%",
             beginAtZero: true,
             ticks: {
               format: { style: "decimal" },
@@ -56,22 +56,22 @@ export default class extends Controller {
         plugins: {
           legend: {
              display: this.displayLegend(),
-             position: 'bottom'
+             position: "bottom"
           },
           datalabels: {
             labels: {
               title: {
                 font: {
-                  weight: 'bold',
+                  weight: "bold",
                   lineHeight: 1.3
                 },
-                textAlign: 'center',
-                align: 'start',
-                anchor: 'end',
-                offset: -35
+                textAlign: "center",
+                align: "top",
+                anchor: "end",
+                offset: 5
               }
             },
-            formatter: getPercentage
+            formatter: calcConversionRates
           }
         }
       }
@@ -89,7 +89,6 @@ export default class extends Controller {
 
   createDataSet(data) {
     return [{
-      //label: this.htmlDecode(label),
       backgroundColor: this.colorPalette[0],
       borderColor: this.colorPalette[0],
       borderWidth: 0,
@@ -122,12 +121,11 @@ export default class extends Controller {
   }
 }
 
-const getPercentage = (value, context) => {
+const calcConversionRates = (value, context) => {
   let percentages = context.chart.data.datasets[0].data.map((element, index, array) => Math.round(element/array[index-1]*100));
-  percentages[0] = '';
+  percentages[0] = "";
   if (context.dataIndex == 0) {
     return value;
   }
-  return value + '\n' + '(' + percentages[context.dataIndex] + '%)';
+  return `${value}\n(${percentages[context.dataIndex]}%)`;
 }
-

--- a/app/javascript/controllers/funnel_chart_controller.js
+++ b/app/javascript/controllers/funnel_chart_controller.js
@@ -1,10 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
-
 import { Chart, registerables } from "chart.js";
-Chart.register(...registerables);
-
 import ChartDataLabels from "chartjs-plugin-datalabels";
-Chart.register(ChartDataLabels);
+
+Chart.register(...registerables);
 
 export default class extends Controller {
   static targets = ["chart"]
@@ -21,13 +19,13 @@ export default class extends Controller {
   showChart() {
     const data = {
       labels: this.funnelEventNamesValue,
-      //datasets: Object.keys(this.funnelDataValue).map((f) => this.createDataSet(f, this.funnelDataValue[e]))
       datasets: this.createDataSet(this.funnelDataValue)
     };
 
     const config = {
       type: "bar",
       data,
+      plugins: [ChartDataLabels],
       options: {
         events: [],
         layout: {
@@ -63,23 +61,17 @@ export default class extends Controller {
           datalabels: {
             labels: {
               title: {
-                color: 'white',
                 font: {
                   weight: 'bold',
                   lineHeight: 1.3
                 },
-                textAlign: 'center'
+                textAlign: 'center',
+                align: 'start',
+                anchor: 'end',
+                offset: -35
               }
             },
-            formatter: (value, context) => {
-              let testValue = this.funnelDataValue.map((x, y, z) => Math.round(x/z[y-1]*100));
-              testValue[0] = '';
-              if (context.dataIndex == 0) {
-                return value
-              } else {
-                return value + '\n' + '(' + testValue[context.dataIndex] + '%)'
-              }
-            }
+            formatter: getPercentage
           }
         }
       }
@@ -128,5 +120,14 @@ export default class extends Controller {
     var doc = new DOMParser().parseFromString(input, "text/html");
     return doc.documentElement.textContent;
   }
+}
+
+const getPercentage = (value, context) => {
+  let percentages = context.chart.data.datasets[0].data.map((element, index, array) => Math.round(element/array[index-1]*100));
+  percentages[0] = '';
+  if (context.dataIndex == 0) {
+    return value;
+  }
+  return value + '\n' + '(' + percentages[context.dataIndex] + '%)';
 }
 

--- a/app/javascript/controllers/funnel_chart_controller.js
+++ b/app/javascript/controllers/funnel_chart_controller.js
@@ -3,6 +3,9 @@ import { Controller } from "@hotwired/stimulus"
 import { Chart, registerables } from "chart.js";
 Chart.register(...registerables);
 
+import ChartDataLabels from "chartjs-plugin-datalabels";
+Chart.register(ChartDataLabels);
+
 export default class extends Controller {
   static targets = ["chart"]
   static values = {
@@ -26,6 +29,7 @@ export default class extends Controller {
       type: "bar",
       data,
       options: {
+        events: [],
         layout: {
           padding: 10,
         },
@@ -37,7 +41,7 @@ export default class extends Controller {
             ticks: {
               format: { style: "decimal" },
               precision: 0,
-              padding: 10,
+              padding: 10
             },
             grid: {
               color: "rgba(254, 243, 199, 0.7)",
@@ -51,11 +55,31 @@ export default class extends Controller {
             }
           }
         },
-        //spanGaps: true,
         plugins: {
           legend: {
              display: this.displayLegend(),
              position: 'bottom'
+          },
+          datalabels: {
+            labels: {
+              title: {
+                color: 'white',
+                font: {
+                  weight: 'bold',
+                  lineHeight: 1.3
+                },
+                textAlign: 'center'
+              }
+            },
+            formatter: (value, context) => {
+              let testValue = this.funnelDataValue.map((x, y, z) => Math.round(x/z[y-1]*100));
+              testValue[0] = '';
+              if (context.dataIndex == 0) {
+                return value
+              } else {
+                return value + '\n' + '(' + testValue[context.dataIndex] + '%)'
+              }
+            }
           }
         }
       }
@@ -69,8 +93,6 @@ export default class extends Controller {
 
   displayLegend() {
     return false;
-    // let objKeys = Object.keys(this.eventsValue)
-    // return objKeys.length != 1 || (objKeys.length === 1 && objKeys[0] !== "")
   }
 
   createDataSet(data) {
@@ -84,7 +106,6 @@ export default class extends Controller {
       hoverBorderColor: "rgb(35, 112, 144)",
       maxBarThickness: 100,
       data: data,
-      //hidden: index > 5
     }]
   }
 
@@ -103,30 +124,9 @@ export default class extends Controller {
     ]
   }
 
-  // formatDates() {
-  //   let dateOption;
-  //   switch(this.aggValue) {
-  //     case "d":
-  //       dateOption = { weekday: "short", year: "2-digit", month: "short", day: "2-digit" };
-  //       break;
-  //     case "w":
-  //       dateOption = { year: "numeric", month: "short", day: "2-digit" };
-  //       break;
-  //     case "m":
-  //       dateOption = { year: "numeric", month: "short" };
-  //       break;
-  //     case "y":
-  //       dateOption = { year: "numeric"};
-  //       break;
-  //   }
-  //   return this.datesValue.map((e) => { 
-  //     let d = new Date(e);
-  //     return d.toLocaleDateString("en-US", dateOption);
-  //   });
-  // }
-
   htmlDecode(input) {
     var doc = new DOMParser().parseFromString(input, "text/html");
     return doc.documentElement.textContent;
   }
 }
+

--- a/app/views/events/_selections.html.erb
+++ b/app/views/events/_selections.html.erb
@@ -3,7 +3,7 @@
   data-controller="event selection"
   data-event-aggregation-value="<%= aggregation %>"
 >
-  <div class="flex flex-col md:flex-row  gap-x-5 items-left md:items-center justify-start">
+  <div class="flex flex-col md:flex-row gap-x-5 items-left md:items-center justify-start">
     <div class="flex flex-col items-start justify-center mb-2 md:mb-0">
       <%= label_tag 'events', 'Events', class: "text-sm font-medium mb-2" %>
       <%= select_tag "events",

--- a/app/views/funnels/_selections.html.erb
+++ b/app/views/funnels/_selections.html.erb
@@ -3,7 +3,7 @@
   data-controller="selection"
 >
   <div class="flex flex-col md:flex-row gap-x-5 items-left md:items-center justify-start">
-    <div class="flex flex-col items-start justify-center">
+    <div class="flex flex-col items-start justify-center mb-2 md:mb-0">
       <%= label_tag 'funnels', 'Funnels', class: "text-sm font-medium mb-2" %>
       <%= select_tag "funnels",
           raw(funnel_select_options(param_data, funnel_names)),
@@ -13,7 +13,7 @@
     </div>
   </div>
   <div class="flex flex-col md:flex-row gap-x-5 items-left md:items-center justify-start">
-    <div class="flex flex-col items-start justify-center">
+    <div class="flex flex-col items-start justify-center mb-2 md:mb-0">
       <%= label_tag 'date_range', 'Date Range', class: "text-sm font-medium mb-2" %>
       <%= select_tag "date_range",
           raw(date_select_options(param_data, nil, "funnel")),

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,10 +5,12 @@
 
 pin "application"
 
-pin "chart.js", to: "https://cdn.jsdelivr.net/npm/chart.js/+esm"
-pin "chartjs-plugin-colorschemes", to: "https://cdn.jsdelivr.net/npm/chartjs-plugin-colorschemes"
+pin "chart.js", to: "https://ga.jspm.io/npm:chart.js@3.7.0/dist/chart.esm.js"
+# pin "chartjs-plugin-colorschemes", to: "https://cdn.jsdelivr.net/npm/chartjs-plugin-colorschemes"
+pin "chartjs-plugin-datalabels", to: "https://ga.jspm.io/npm:chartjs-plugin-datalabels@2.0.0/dist/chartjs-plugin-datalabels.esm.js"
 pin "@hotwired/stimulus", to: "stimulus.js"
 pin "@hotwired/stimulus-importmap-autoloader", to: "stimulus-importmap-autoloader.js"
 
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
+pin "chart.js/helpers", to: "https://ga.jspm.io/npm:chart.js@3.7.0/helpers/helpers.esm.js"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,11 +6,10 @@
 pin "application"
 
 pin "chart.js", to: "https://ga.jspm.io/npm:chart.js@3.7.0/dist/chart.esm.js"
-# pin "chartjs-plugin-colorschemes", to: "https://cdn.jsdelivr.net/npm/chartjs-plugin-colorschemes"
 pin "chartjs-plugin-datalabels", to: "https://ga.jspm.io/npm:chartjs-plugin-datalabels@2.0.0/dist/chartjs-plugin-datalabels.esm.js"
+pin "chart.js/helpers", to: "https://ga.jspm.io/npm:chart.js@3.7.0/helpers/helpers.esm.js"
 pin "@hotwired/stimulus", to: "stimulus.js"
 pin "@hotwired/stimulus-importmap-autoloader", to: "stimulus-importmap-autoloader.js"
 
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
-pin "chart.js/helpers", to: "https://ga.jspm.io/npm:chart.js@3.7.0/helpers/helpers.esm.js"


### PR DESCRIPTION
- installed new plugin "chartjs-plugin-datalabels" (https://chartjs-plugin-datalabels.netlify.app/)
- made value and percentage white and centered in bar
- calculation is done directly in showChart() function in the section plugins -> datalables to get access to each bar individually
- disabled hover and click functionality (because value is already shown)
<img width="1097" alt="Screenshot 2022-01-26 at 17 11 20" src="https://user-images.githubusercontent.com/32681439/151201706-fea23d8f-01cb-4e12-a18c-4ec63da753ff.png">
<img width="424" alt="Screenshot 2022-01-26 at 17 11 43" src="https://user-images.githubusercontent.com/32681439/151201775-5a27efe6-2277-47c6-ab0c-579dd4c04ffc.png">

questions:
- maybe it would be better to place the label on top of bar and make it black, in case there is a long funnel and the bar gets to narrow?
- is it bad to calculate it inside the showChart() function?


